### PR TITLE
Fix plugin wiki URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### A simple docker images used for demo [Splunk Plugin for Jenkins](wiki.jenkins-ci.org/display/JENKINS/Splunk+Plugin+for+Jenkins)
+### A simple docker images used for demo [Splunk Plugin for Jenkins](https://wiki.jenkins-ci.org/display/JENKINS/Splunk+Plugin+for+Jenkins)
 
 ### Run
 	curl -s -L https://raw.githubusercontent.com/fengxx/docker-splunk-app-jenkins/master/demo.sh | sh


### PR DESCRIPTION
Otherwise, the link will be: https://github.com/fengxx/docker-splunk-app-jenkins/blob/master/wiki.jenkins-ci.org/display/JENKINS/Splunk+Plugin+for+Jenkins   

Thanks for the great work!